### PR TITLE
Update RL environments to support passing config to gym.make

### DIFF
--- a/tests/test_simulators.py
+++ b/tests/test_simulators.py
@@ -20,6 +20,7 @@ def check_shapes(dataset, num_samples):
     "simulator",
     [
         wn.delayed_impact,
+        wn.credit,
         wn.hiv,
         wn.lotka_volterra,
         wn.opioid,
@@ -29,6 +30,7 @@ def check_shapes(dataset, num_samples):
     ],
     ids=[
         "delayed_impact",
+        "credit",
         "hiv",
         "lotka_volterra",
         "opioid",

--- a/whynot/gym/envs/ode_env.py
+++ b/whynot/gym/envs/ode_env.py
@@ -1,4 +1,5 @@
 """Environment builder for simulators based on dynamical systems."""
+import copy
 import inspect
 
 from whynot.gym import Env
@@ -149,7 +150,10 @@ class ODEEnvBuilder(Env):
             kwargs["time"] = self.time
         return self.reward_fn(intervention=intervention, state=state, **kwargs)
 
-    def __call__(self):
+    def __call__(self, config=None):
         """Return the class, as if this function were calling the constructor."""
-        self.reset()
-        return self
+        env = copy.deepcopy(self)
+        if config:
+            env.config = config
+        env.reset()
+        return env

--- a/whynot/simulators/credit/environments.py
+++ b/whynot/simulators/credit/environments.py
@@ -1,11 +1,11 @@
 """Interactive environment for the credit simulator."""
+import copy
+
 import numpy as np
 
 from whynot.gym import spaces
 from whynot.gym.envs import ODEEnvBuilder, register
 from whynot.simulators.credit import (
-    agent_model,
-    CreditData,
     Config,
     Intervention,
     simulate,
@@ -26,38 +26,76 @@ def compute_intervention(action, time):
     return Intervention(time=time, theta=action)
 
 
-CreditEnv = ODEEnvBuilder(
-    simulate_fn=simulate,
-    config=Config(),
-    # The initial state is the baseline features and labels in the credit dataset
-    initial_state=State(features=CreditData.features, labels=CreditData.labels),
-    # Action space is classifiers with the same number of parameters are
-    # features.
-    action_space=spaces.Box(
-        low=-np.inf, high=np.inf, shape=(CreditData.num_features,), dtype=np.float64
-    ),
-    # Observation space is the strategically adapted features and labels
-    observation_space=spaces.Dict(
+def credit_action_space(initial_state):
+    """Return action space for credit simulator.
+    
+    The action space is the vector of possible logistic regression
+    parameters, which depends on the dimensionality of the features.
+    """
+    num_features = initial_state.features.shape[1]
+    return spaces.Box(low=-np.inf, high=np.inf, shape=(num_features,), dtype=np.float64)
+
+
+def credit_observation_space(initial_state):
+    """Return observation space for credit simulator.
+    
+    The observation space is the vector of possible datasets, which
+    must have the same dimensions as the initial state.
+    """
+    return spaces.Dict(
         {
             "features": spaces.Box(
                 low=-np.inf,
                 high=np.inf,
-                shape=CreditData.features.shape,
+                shape=initial_state.features.shape,
                 dtype=np.float64,
             ),
             "labels": spaces.Box(
                 low=-np.inf,
                 high=np.inf,
-                shape=CreditData.labels.shape,
+                shape=initial_state.labels.shape,
                 dtype=np.float64,
             ),
         }
-    ),
-    timestep=1,
-    intervention_fn=compute_intervention,
-    reward_fn=compute_reward,
-)
+    )
+
+
+def build_credit_env(config=None, initial_state=None):
+    """Construct credit environment that is parameterized by the initial state.
+
+    This allows the user to specify different datasets other than the default
+    Credit dataset.
+    """
+    if config is None:
+        config = Config()
+    elif not isinstance(config, Config):
+        raise ValueError(f"Config must be an instance of {type(Config())}")
+    if initial_state is None:
+        initial_state = State()
+    elif not isinstance(initial_state, State):
+        raise ValueError(f"Initial state must be an instance of {type(State())}")
+
+    config.base_state = copy.deepcopy(initial_state)
+
+    return ODEEnvBuilder(
+        simulate_fn=simulate,
+        config=config,
+        # The initial state is the baseline features and labels in the credit dataset
+        initial_state=initial_state,
+        # Action space is classifiers with the same number of parameters are
+        # features.
+        action_space=credit_action_space(initial_state),
+        # Observation space is the strategically adapted features and labels
+        observation_space=credit_observation_space(initial_state),
+        timestep=1,
+        intervention_fn=compute_intervention,
+        reward_fn=compute_reward,
+    )
+
 
 register(
-    id="Credit-v0", entry_point=CreditEnv, max_episode_steps=100, reward_threshold=0,
+    id="Credit-v0",
+    entry_point=build_credit_env,
+    max_episode_steps=100,
+    reward_threshold=0,
 )


### PR DESCRIPTION
Environments now support passing a simulator config to `gym.make`, e.g.
```
import whynot as wn
import whynot.gym as gym

config = wn.credit.Config(epsilon=100)
env = gym.make('Credit-v0', config=config)
```
The `Credit` environment additionally support passing an `initial_state` at construction to define
the dataset used during retraining, e.g.
```
import whynot as wn
import whynot.gym as gym

# Subsample data
all_features, all_labels = wn.credit.CreditData.features, wn.credit.CreditData.labels
features, labels = all_features[:100], all_labels[:100]
env = gym.make('Credit-v0', initial_state=wn.credit.State(features, labels))

```