### PR TITLE
Changed strategic logistic loss to avoid adding a second gaming stage

### DIFF
--- a/whynot/simulators/credit/__init__.py
+++ b/whynot/simulators/credit/__init__.py
@@ -6,7 +6,7 @@ from whynot.simulators.credit.simulator import (
     dynamics,
     Intervention,
     simulate,
-    strategic_logistic_loss,
+    logistic_loss,
     State,
 )
 

--- a/whynot/simulators/credit/environments.py
+++ b/whynot/simulators/credit/environments.py
@@ -9,14 +9,14 @@ from whynot.simulators.credit import (
     Config,
     Intervention,
     simulate,
-    strategic_logistic_loss,
+    logistic_loss,
     State,
 )
 
 
 def compute_reward(intervention, state, config):
     """Compute the reward based on the observed state and choosen intervention."""
-    return strategic_logistic_loss(
+    return logistic_loss(
         config, state.features, state.labels, intervention.updates["theta"],
     )
 

--- a/whynot/simulators/credit/simulator.py
+++ b/whynot/simulators/credit/simulator.py
@@ -109,12 +109,9 @@ def strategic_logistic_loss(config, features, labels, theta):
 
     config = config.update(Intervention(theta=theta))
 
-    # Compute adjusted data
-    strategic_features = agent_model(features, config)
-
     # compute log likelihood
-    num_samples = strategic_features.shape[0]
-    logits = strategic_features @ config.theta
+    num_samples = features.shape[0]
+    logits = features @ config.theta
     log_likelihood = (1.0 / num_samples) * np.sum(
         -1.0 * np.multiply(labels, logits) + np.log(1 + np.exp(logits))
     )

--- a/whynot/simulators/credit/simulator.py
+++ b/whynot/simulators/credit/simulator.py
@@ -104,7 +104,7 @@ class Intervention(BaseIntervention):
         super(Intervention, self).__init__(Config, time, **kwargs)
 
 
-def strategic_logistic_loss(config, features, labels, theta):
+def logistic_loss(config, features, labels, theta):
     """Evaluate the performative loss for logistic regression classifier."""
 
     config = config.update(Intervention(theta=theta))


### PR DESCRIPTION
The original code in the `credit` simulator calls `agent_model()` and adds the strategic response twice:

* once in `dynamics()` (called by `simulate()`) 
* then again, on the same state object updated by the ODE env when computing reward, `strategic_logistic_loss()`

This means the perturbation gets double-counted when computing reward for the env.
I removed the second call, which should fix it.

(I don't think this changes much, it's equivalent to doubling \epsilon, but, eh, for posterity.)
One more minor note: technically the name of the function, `strategic_logistic_loss()`, is no longer really appropriate - it's now more of "convex logistic loss" - but I leave that to the original authors to correct if they want.